### PR TITLE
implement a byname lookup shortcut

### DIFF
--- a/slack_cleaner2/model.py
+++ b/slack_cleaner2/model.py
@@ -615,7 +615,7 @@ class ByNameLookup(Generic[ByName]):
       return self._arr[key]
     return next((v for v in self._arr if cast(Any, v).name == key), None)
 
-  def __getattr__ (self, name: str) -> Optional[ByName]:
+  def __getattr__(self, name: str) -> Optional[ByName]:
     return self[name]
 
   def __len__(self) -> int:


### PR DESCRIPTION
simplifies direct channel access, e..g

```python
s = SlackCleaner(...)
general = s.c.general
```