### PR TITLE
Fix resolve_user typo in file()

### DIFF
--- a/slack_cleaner2/model.py
+++ b/slack_cleaner2/model.py
@@ -509,7 +509,7 @@ class SlackFile:
             page = current_page + 1
 
             for sfile in files:
-                yield SlackFile(sfile, slack.get_user(sfile["user"]), slack)
+                yield SlackFile(sfile, slack.resolve_user(sfile["user"]), slack)
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
Fixes an error when looking up file owners.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xxxx/slack_cleaner2/slack_cleaner2/model.py", line 512, in list
    yield SlackFile(sfile, slack.get_user(sfile["user"]), slack)
AttributeError: 'SlackCleaner' object has no attribute 'get_user'
```
Appears to be a typo since after changing it to `resolve_user` everything works as expected.