### PR TITLE
Exclude tombstoned files from the files attribute of SlackMessage.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.3.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_requirements = ["pytest"]
 setup(
     name="slack_cleaner2",
     description="Slack Cleaner2 is an improved slack cleaner version using a python first approach",
-    version="2.2.0",
+    version="2.3.0",
     license="MIT license",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/slack_cleaner2/_info.py
+++ b/slack_cleaner2/_info.py
@@ -4,4 +4,4 @@
 __author__ = """Samuel Gratzl"""
 __email__ = "sam@sgratzl.com"
 __license__ = "MIT License"
-__version__ = "2.2.0"
+__version__ = "2.3.0"

--- a/slack_cleaner2/model.py
+++ b/slack_cleaner2/model.py
@@ -404,7 +404,7 @@ class SlackMessage:
         self.pinned_to = entry.get("pinned_to", False)
         self.has_replies = entry.get("reply_count", 0) > 0
         self.thread_ts = float(entry.get("thread_ts", entry["ts"]))
-        self.files = [SlackFile(f, user if user else slack.resolve_user(f["user"]), slack) for f in entry.get("files", [])]
+        self.files = [SlackFile(f, user if user else slack.resolve_user(f["user"]), slack) for f in entry.get("files", []) if f["mode"] != "tombstone"]
         self.is_tombstone = entry.get("subtype", None) == "tombstone"
 
     def delete(self, as_user=True, files=False, replies=False) -> Optional[Exception]:


### PR DESCRIPTION
The present implementation throws KeyError on tombstoned files, because they
don't have a name (or most other "entry" attributes"):

```
  File "/home/mary/src/slack_cleaner2/slack_cleaner2/model.py", line 537, in __init__
    self.name = entry["name"]
```